### PR TITLE
Refactor Slurm code into cw.slurm module.

### DIFF
--- a/cw/__init__.py
+++ b/cw/__init__.py
@@ -9,8 +9,6 @@ import getpass
 PORT = 5494
 # Some random bytes to separate messages.
 SENTINEL = b'\x8d\xa9 \xee\x01\xe6B\xec\xaa\n\xe1A:\x15\x8d\x1b'
-JOB_MASTER ='cmaster'
-JOB_WORKERS = 'cworkers'
 
 def randid():
     return random.getrandbits(128)
@@ -107,26 +105,3 @@ def _readmsg(conn):
     obj = _msg_deser(data)
     yield bluelet.end(obj)
 
-
-# Slurm utilities.
-
-def slurm_jobinfo():
-    """Uses "squeue" to generate a list of job information tuples. The
-    tuples are of the form (jobid, jobname, username, nodelist).
-    """
-    joblist = subprocess.check_output(
-        ['squeue', '-o', '%i %j %u %N', '-h']
-    ).strip()
-    if not joblist:
-        return
-    for line in joblist.split('\n'):
-        jobid, name, user, nodelist = line.split(' ', 3)
-        yield int(jobid), name, user, nodelist
-
-def slurm_master_host():
-    cur_user = getpass.getuser()
-    for jobid, name, user, nodelist in slurm_jobinfo():
-        if name == JOB_MASTER and user == cur_user:
-            assert '[' not in nodelist
-            return nodelist
-    assert False, 'no master job found'

--- a/cw/slurm.py
+++ b/cw/slurm.py
@@ -1,0 +1,142 @@
+from __future__ import print_function
+import re
+import os
+import tempfile
+import subprocess
+import sys
+import time
+import argparse
+import cw
+import getpass
+
+
+JOB_MASTER ='cmaster'
+JOB_WORKERS = 'cworkers'
+
+
+def _jobinfo():
+    """Uses "squeue" to generate a list of job information tuples. The
+    tuples are of the form (jobid, jobname, username, nodelist).
+    """
+    joblist = subprocess.check_output(
+        ['squeue', '-o', '%i %j %u %N', '-h']
+    ).strip()
+    if not joblist:
+        return
+    for line in joblist.split('\n'):
+        jobid, name, user, nodelist = line.split(' ', 3)
+        yield int(jobid), name, user, nodelist
+
+
+def master_host():
+    cur_user = getpass.getuser()
+    for jobid, name, user, nodelist in _jobinfo():
+        if name == JOB_MASTER and user == cur_user:
+            assert '[' not in nodelist
+            return nodelist
+    assert False, 'no master job found'
+
+def _sbatch(job):
+    """Submits a Slurm job represented as a sbatch script string. Returns
+    the job ID.
+    """
+    jobfile = tempfile.NamedTemporaryFile(delete=False)
+    jobfile.write(job)
+    jobfile.close()
+    try:
+        out = subprocess.check_output(['sbatch', jobfile.name])
+    finally:
+        os.unlink(jobfile.name)
+
+    jobid = re.search(r'job (\d+)', out).group(1)
+    return int(jobid)
+
+
+def _startjob(command, name=None, options=[]):
+    """Start a Slurm job and return the job ID."""
+    if name:
+        options.append('--job-name={}'.format(name))
+        options.append('--output={}.out'.format(name))
+        options.append('--error={}.out'.format(name))
+
+    script_lines = ["#!/bin/sh"]
+    if options:
+        script_lines.append('#SBATCH ' + ' '.join(options))
+    script_lines.append('srun ' + command)
+
+    return _sbatch('\n'.join(script_lines))
+
+
+def _scancel(jobid, signal='INT'):
+    """Cancel a Slurm job given its ID.
+    """
+    subprocess.check_call(
+        ['scancel', '-s', signal, str(jobid)]
+    )
+
+
+def _get_jobid(jobname):
+    """Given a job name, return the ID of a job belonging to this user
+    matching that name or None if not found.
+    """
+    cur_user = getpass.getuser()
+    for jobid, name, user, nodelist in _jobinfo():
+        if name == jobname and user == cur_user:
+            return jobid
+
+
+def _start_workers(num=2, options=[], docker_image=None, docker_args=""):
+    if docker_image:
+        command = "docker run -i --rm --net=host {} {} -m cw.worker {}".format(
+            docker_args, docker_image, master_host()
+        )
+    else:
+        command = "{} -m cw.worker --slurm".format(sys.executable)
+    options = ['--ntasks={}'.format(num)] + options
+    return _startjob(command, JOB_WORKERS, options)
+
+
+def _start_master(options=[]):
+    """Start a job for the master process. Return the Slurm job ID.
+    """
+    command = "{} -m cw.master".format(sys.executable)
+    return _startjob(command, JOB_MASTER, options)
+
+
+def start(nworkers, master=True, workers=True, master_options=[],
+          worker_options=[], docker_image=None, docker_args=""):
+    """Start up a cluster of workers using Slurm. Note that only one
+    cluster should be in operation at a given time (only one 'cmaster').
+    If no docker_image is specified, docker will not be used.
+    """
+    # Master.
+    if master:
+        print('starting master')
+        jobid = _start_master(master_options)
+        print('master job', jobid, 'started')
+        time.sleep(5)
+        print('master running on', master_host())
+
+    # Workers.
+    if workers:
+        print('starting {} workers'.format(nworkers))
+        jobid = _start_workers(nworkers, worker_options,
+                              docker_image, docker_args)
+        print('worker job', jobid, 'started')
+
+
+def stop(master=True, workers=True):
+    """Stop the running of a cluster (shut down cmaster and all cworkers).
+    """
+    # Workers.
+    worker_jobid = _get_jobid(JOB_WORKERS)
+    if worker_jobid:
+        print('stopping workers')
+        _scancel(worker_jobid)
+        time.sleep(5)
+
+    # Master.
+    master_jobid = _get_jobid(JOB_MASTER)
+    if master_jobid:
+        print('stopping master')
+        _scancel(master_jobid)

--- a/examples/square.py
+++ b/examples/square.py
@@ -1,4 +1,5 @@
 import cw.client
+import cw.slurm
 
 
 def completion(jobid, output):
@@ -17,10 +18,20 @@ def work(n):
 
 
 def main():
+    
+    # If you wish to start a worker cluster just for this script, you
+    # can do so with a command like this. See the slurm module for
+    # more info on the available options. 
+    #
+    # Note: If you are running multiple cluster-workers scripts, be 
+    # careful with this because only one set of master/workers can be
+    # running at a time.
+    cw.slurm.start(nworkers=2)
+    
     # Set up the client, connecting to the mast host. Replace the second
     # argument below with 'localhost' if you want to connect to a local
     # (i.e., development) cluster.
-    client = cw.client.ClientThread(completion, cw.slurm_master_host())
+    client = cw.client.ClientThread(completion, cw.slurm.master_host())
     client.start()
 
     # Submit a bunch of work.
@@ -35,7 +46,11 @@ def main():
     # the results of all of our work before shutting down the
     # interpreter.
     client.wait()
-
+    
+    # If you started the worker cluster programmatically above, you 
+    # can safely shut down the cluster workers. This will free up the
+    # nodes.
+    cw.slurm.stop()
 
 if __name__ == '__main__':
     main()

--- a/slurm.py
+++ b/slurm.py
@@ -13,107 +13,6 @@ import getpass
 DEFAULT_WORKERS = 32
 
 
-def sbatch(job):
-    """Submits a Slurm job represented as a sbatch script string. Returns
-    the job ID.
-    """
-    jobfile = tempfile.NamedTemporaryFile(delete=False)
-    jobfile.write(job)
-    jobfile.close()
-    try:
-        out = subprocess.check_output(['sbatch', jobfile.name])
-    finally:
-        os.unlink(jobfile.name)
-
-    jobid = re.search(r'job (\d+)', out).group(1)
-    return int(jobid)
-
-
-def startjob(command, name=None, options=()):
-    """Start a Slurm job and return the job ID."""
-    options = list(options)
-    if name:
-        options.append('--job-name={}'.format(name))
-        options.append('--output={}.out'.format(name))
-        options.append('--error={}.out'.format(name))
-
-    script_lines = ["#!/bin/sh"]
-    if options:
-        script_lines.append('#SBATCH ' + ' '.join(options))
-    script_lines.append('srun ' + command)
-
-    return sbatch('\n'.join(script_lines))
-
-
-def scancel(jobid, signal='INT'):
-    """Cancel a Slurm job given its ID.
-    """
-    subprocess.check_call(
-        ['scancel', '-s', signal, str(jobid)]
-    )
-
-
-def get_jobid(jobname):
-    """Given a job name, return the ID of a job belonging to this user
-    matching that name or None if not found.
-    """
-    cur_user = getpass.getuser()
-    for jobid, name, user, nodelist in cw.slurm_jobinfo():
-        if name == jobname and user == cur_user:
-            return jobid
-
-
-def start_workers(num=2, options=(), docker_image=None, docker_args=""):
-    if docker_image:
-        command = "docker run -i --rm --net=host {} {} -m cw.worker {}".format(
-            docker_args, docker_image, cw.slurm_master_host()
-        )
-    else:
-        command = "{} -m cw.worker --slurm".format(sys.executable)
-    options = ['--ntasks={}'.format(num)] + options
-    return startjob(command, cw.JOB_WORKERS, options)
-
-
-def start_master(options=()):
-    """Start a job for the master process. Return the Slurm job ID.
-    """
-    command = "{} -m cw.master".format(sys.executable)
-    return startjob(command, cw.JOB_MASTER, options)
-
-
-def start(nworkers, master=True, workers=True, master_options=(),
-          worker_options=(), docker_image=None, docker_args=""):
-    # Master.
-    if master:
-        print('starting master')
-        jobid = start_master(master_options)
-        print('master job', jobid, 'started')
-        time.sleep(5)
-        print('master running on', cw.slurm_master_host())
-
-    # Workers.
-    if workers:
-        print('starting {} workers'.format(nworkers))
-        jobid = start_workers(nworkers, worker_options,
-                              docker_image, docker_args)
-        print('worker job', jobid, 'started')
-
-
-def stop(master=True, workers=True):
-    # Workers.
-    worker_jobid = get_jobid(cw.JOB_WORKERS)
-    if worker_jobid:
-        print('stopping workers')
-        scancel(worker_jobid)
-        time.sleep(5)
-
-    # Master.
-    master_jobid = get_jobid(cw.JOB_MASTER)
-    if master_jobid:
-        print('stopping master')
-        scancel(master_jobid)
-
-
 def cli():
     parser = argparse.ArgumentParser(
         description='start Python workers on a Slurm cluster'
@@ -162,11 +61,11 @@ def cli():
         worker_options.append('--ntasks-per-node=1')
 
     if args.action == 'start':
-        start(args.nworkers, args.master, args.workers,
+        cw.slurm.start(args.nworkers, args.master, args.workers,
               args.master_options, worker_options,
               args.docker_image, args.docker_args)
     elif args.action == 'stop':
-        stop(args.master, args.workers)
+        cw.slurm.stop(args.master, args.workers)
     else:
         parser.error('action must be stop or start')
 


### PR DESCRIPTION
Now it is possible to programmatically start/stop a worker cluster from
a script (see square.py example).

Fixes #6.

@sampsyo please feel free to fix (or tell me to fix) any style issues. I thought I'd make most of the functions "module-local" but we could go back on that. Also, if you'd prefer, we could make a separate example that illustrates starting and stopping the cluster programmatically so we don't clutter the squares.py example.