### PR TITLE
Fixes to Slurm refactoring.

### DIFF
--- a/cw/client.py
+++ b/cw/client.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import cw
+import cw.slurm
 import bluelet
 import threading
 import concurrent.futures
@@ -178,8 +179,9 @@ class ClusterExecutor(concurrent.futures.Executor):
 
 
 class SlurmExecutor(ClusterExecutor):
+    
     def __init__(self):
-        super(SlurmExecutor, self).__init__(cw.slurm_master_host())
+        super(SlurmExecutor, self).__init__(cw.slurm.master_host())
 
 
 def test():

--- a/cw/worker.py
+++ b/cw/worker.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import cw
+import cw.slurm
 import bluelet
 import traceback
 import sys
@@ -99,7 +100,6 @@ if __name__ == '__main__':
     args = sys.argv[1:]
 
     if args and args[0] == '--slurm':
-        import cw.slurm
         host = cw.slurm.master_host()
     elif args:
         host = args[0]

--- a/cw/worker.py
+++ b/cw/worker.py
@@ -99,7 +99,8 @@ if __name__ == '__main__':
     args = sys.argv[1:]
 
     if args and args[0] == '--slurm':
-        host = cw.slurm_master_host()
+        import cw.slurm
+        host = cw.slurm.master_host()
     elif args:
         host = args[0]
     else:

--- a/slurm.py
+++ b/slurm.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import time
 import argparse
-import cw
+import cw.slurm
 import getpass
 
 DEFAULT_WORKERS = 32


### PR DESCRIPTION
Oops, I missed a couple places where I needed to change `cw.slurm_master_host()` to `cw.slurm.master_host()`. Apparently it ran fine because I hadn't re-installed the new version of cluster-workers with `setup.py install`, so the worker and master were running with the old code. :/

I think this should do it.